### PR TITLE
Update deprecated PropTypes Call

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gulp-concat-css": "^2.3.0",
     "gulp-copy": "^1.0.0",
     "gulp-util": "3.0.7",
+    "prop-types": "^15.5.10",
     "react": "15.4.2",
     "react-dom": "15.4.2",
     "webpack": "1.13.3"
@@ -35,6 +36,6 @@
     "superagent": "3.4.1"
   },
   "peerDependencies": {
-    "react": "15.4.2"
+    "react": "^15.5.4"
   }
 }

--- a/src/components/Hologram.js
+++ b/src/components/Hologram.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Dropzone from 'react-dropzone';
 import ModalCom from "./Modal";
 import request from 'superagent';
+import PropTypes from 'prop-types';
 
 class Hologram extends React.Component {
     constructor(props) {
@@ -158,11 +159,11 @@ class Hologram extends React.Component {
 };
 
 static propTypes = {
-    cropperConfig: React.PropTypes.object,
-    dropzoneConfig: React.PropTypes.object,
-    maxFiles: React.PropTypes.number,
-    uploader: React.PropTypes.string.isRequired,
-    onComplete: React.PropTypes.func,
+  cropperConfig: PropTypes.object,
+  dropzoneConfig: PropTypes.object,
+  maxFiles: PropTypes.number,
+  uploader: PropTypes.string.isRequired,
+  onComplete: PropTypes.func,
 };
 
 static defaultProps = {


### PR DESCRIPTION
Hi!

I have noticed that the way you were calling the PropTypes is deprecated in the latest version of React. 	I added the prop-types package to the project and changed the PropTypes call. 